### PR TITLE
Made compatible as an ESP-IDF component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "FastTrig.cpp"
+                    INCLUDE_DIRS .)
+
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/FastTrig.cpp
+++ b/FastTrig.cpp
@@ -9,6 +9,9 @@
 
 
 #include "FastTrig.h"
+#ifdef ESP_PLATFORM
+#define boolean bool
+#endif
 
 
 // 91 x 2 bytes ==> 182 bytes

--- a/FastTrig.h
+++ b/FastTrig.h
@@ -11,11 +11,19 @@
 // HISTORY: see changelog.md
 
 
+#ifdef ESP_PLATFORM
+#include <math.h>
+#else
 #include "Arduino.h"
+#endif
 
 
 #define FAST_TRIG_LIB_VERSION             (F("0.1.11"))
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 extern uint16_t isinTable16[];
 extern uint8_t isinTable8[];
@@ -48,5 +56,8 @@ float iacos(float f);
 // PLACEHOLDER no good implementation
 float iatan(float f);
 
+#ifdef __cplusplus
+}
+#endif
 
 // -- END OF FILE --


### PR DESCRIPTION
Thanks for this faster sin/cos. Works perfect with my POV project.
That said, I'm using ESP-IDF (no arduino) for my project.  Your core code is compatible with the ESP-IDF framework, except for a few very minor details. The `#include "Arduino.h"` for example.  
Here is the code changes I had to make to make your library work with ESP-IDF.
Quite trivial IMO, and I think you'd be able to include some or all of these changes into your code.
You're welcome to just take the changes as you see them, and add them manually, or merge this PR.. what ever works for you.